### PR TITLE
mm-radio: Add vscode tasks file with appropriate problem matchers

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,48 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "problemMatcher": [
+                {
+                    "owner": "mm",
+                    "pattern": [
+                        {
+                            "regexp":
+                                    "^\/home\/user\/mm-radio\/(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3,
+                            "severity": 4,
+                            "message": 5,
+                        },
+                    ]
+                },
+                {
+                    "owner": "mm1",
+                    "pattern": [
+                        {
+                            "regexp":
+                                    "^(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3,
+                            "severity": 4,
+                            "message": 5,
+                        }
+                    ]
+                }
+            ],
+            "command": "make ci",
+            // "command": "make ci_fast",
+            // "command": "make bd",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Press ctrl-shift-b in vscode to run ci script and see errors.
