### PR TITLE
mm-radio: Enforce clang-tidy readability checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,3 +12,35 @@ CheckOptions:
     value:           '1000.0'
   - key:             readability-function-cognitive-complexity.IgnoreMacros
     value:           1
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.ConstCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           'UPPER_CASE'
+  - key:             readability-identifier-naming.FunctionCase
+    value:           'camelBack'
+  - key:             readability-identifier-naming.GlobalVariableCase
+    value:           'camelBack'
+  - key:             readability-identifier-naming.LocalConstantCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.LocalConstantPrefix
+    value:           'k'
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'camelBack'
+  - key:             readability-identifier-naming.LocalVariablePrefix
+    value:           ''
+  - key:             readability-identifier-naming.MemberCase
+    value:           'camelBack'
+  - key:             readability-identifier-naming.PrivateMemberCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.PrivateMemberPrefix
+    value:           'm'
+  - key:             readability-identifier-naming.NamespaceCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           'camelBack'
+  - key:             readability-identifier-naming.StructCase
+    value:           'CamelCase'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
-on: [push]
+on:
+  pull_request:
+    type: [synchronize]
 
 jobs:
   hello_world_job:
@@ -7,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run CI
         id: hello
         uses: ./.github/workflows/

--- a/src/RadioModem.cpp
+++ b/src/RadioModem.cpp
@@ -56,7 +56,7 @@ ScopedAStatus RadioModem::getDeviceIdentity(int32_t serial) {
 ScopedAStatus RadioModem::getHardwareConfig(int32_t serial) {
     LOG_CALL << serial;
 
-    auto hw_config = std::vector<aidl::HardwareConfig>();
+    auto hwConfig = std::vector<aidl::HardwareConfig>();
     auto modem = (aidl::HardwareConfig){
             .type = aidl::HardwareConfig::TYPE_MODEM,
             .uuid = "MODEM-UUID-TODO",                     // TODO(nobody)
@@ -82,10 +82,10 @@ ScopedAStatus RadioModem::getHardwareConfig(int32_t serial) {
 
     modem.modem.emplace_back(modemConfig);
     sim.sim.emplace_back(simConfig);
-    hw_config.emplace_back(modem);
-    hw_config.emplace_back(sim);
+    hwConfig.emplace_back(modem);
+    hwConfig.emplace_back(sim);
 
-    mResponse->getHardwareConfigResponse(okay(serial), hw_config);
+    mResponse->getHardwareConfigResponse(okay(serial), hwConfig);
 
     return ok();
 }

--- a/src/RadioNetwork.cpp
+++ b/src/RadioNetwork.cpp
@@ -385,14 +385,14 @@ ScopedAStatus RadioNetwork::supplyNetworkDepersonalization(int32_t serial,
 
 ScopedAStatus RadioNetwork::setUsageSetting(int32_t serial, aidl::UsageSetting usageSetting) {
     LOG_UNIMPLEMENTED << serial;
-    state.usageSetting = usageSetting;
+    mState.usageSetting = usageSetting;
     mResponse->setUsageSettingResponse(okay(serial));
     return ok();
 }
 
 ScopedAStatus RadioNetwork::getUsageSetting(int32_t serial) {
     LOG_STUB << serial;
-    mResponse->getUsageSettingResponse(okay(serial), state.usageSetting);
+    mResponse->getUsageSettingResponse(okay(serial), mState.usageSetting);
     return ok();
 }
 

--- a/src/RadioNetwork.h
+++ b/src/RadioNetwork.h
@@ -100,7 +100,7 @@ class RadioNetwork : public aidl::android::hardware::radio::network::BnRadioNetw
     std::shared_ptr<::aidl::android::hardware::radio::network::IRadioNetworkIndication> mIndication;
 
   private:
-    RadioNetworkState state;
+    RadioNetworkState mState;
 };
 
 }  // namespace android::hardware::radio::mm


### PR DESCRIPTION
This patch adds several readability checks and unifies the code.
