### PR TITLE
mm-radio: Implement USSD functionality

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ srcs = [
     'src/mm/Modem.cpp',
     'src/mm/ModemManager.cpp',
     'src/mm/ModemVoice.cpp',
+    'src/mm/ModemUssd.cpp',
 ]
 
 cflags = ['-Wno-unused-parameter']

--- a/src/RadioVoice.h
+++ b/src/RadioVoice.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 
+#include "mm/ModemUssd.h"
 #include "mm/ModemVoice.h"
 
 namespace android::hardware::radio::mm {
@@ -87,9 +88,15 @@ class RadioVoice : public aidl::android::hardware::radio::voice::BnRadioVoice {
     std::shared_ptr<::aidl::android::hardware::radio::voice::IRadioVoiceIndication> mIndication;
 
     std::shared_ptr<ModemVoice> mModemVoice;
+    std::shared_ptr<ModemUssd> mModemUssd;
 
   public:
-    void bindModem(std::shared_ptr<ModemVoice> modemVoice) { mModemVoice = std::move(modemVoice); }
+    void bindModem(std::shared_ptr<ModemVoice> modemVoice, std::shared_ptr<ModemUssd> modemUssd) {
+        mModemVoice = std::move(modemVoice);
+        mModemUssd = std::move(modemUssd);
+    }
+
+    void ussdReceived(MMModem3gppUssdSessionState state, const std::string& message);
 
     void callStateChanged();
 };

--- a/src/mm/ModemObject.h
+++ b/src/mm/ModemObject.h
@@ -20,6 +20,7 @@
 
 #include "MmRaii.h"
 #include "Modem.h"
+#include "ModemUssd.h"
 #include "ModemVoice.h"
 
 class ModemObject {
@@ -29,6 +30,7 @@ class ModemObject {
 
         modemInstance->mModem = Modem::createInstance(mmObject);
         modemInstance->mModemVoice = ModemVoice::createInstance(mmObject);
+        modemInstance->mModemUssd = ModemUssd::createInstance(mmObject);
 
         modemInstance->mModemPath = mm_object_get_path(mmObject.get());
 
@@ -42,6 +44,7 @@ class ModemObject {
     auto& getPath() { return mModemPath; }
     auto& getModem() { return mModem; }
     auto& getVoice() { return mModemVoice; }
+    auto& getUssd() { return mModemUssd; }
 
   private:
     explicit ModemObject(SharedMmObject& mmObject) : mMmObject(mmObject) {}
@@ -52,4 +55,5 @@ class ModemObject {
 
     std::shared_ptr<Modem> mModem;
     std::shared_ptr<ModemVoice> mModemVoice;
+    std::shared_ptr<ModemUssd> mModemUssd;
 };

--- a/src/mm/ModemUssd.cpp
+++ b/src/mm/ModemUssd.cpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// (c) 2023 GloDroid project (https://github.com/GloDroid/mm-radio)
+
+#include "ModemUssd.h"
+
+#include <cutils/log.h>
+
+auto ModemUssd::commonCallbackFunc(ModemUssd* self) -> int {
+    auto state = mm_modem_3gpp_ussd_get_state(self->mMmModem3gppUssd.get());
+    if (self->mUssdReceivedCallback != nullptr)
+        self->mUssdReceivedCallback(state, self->mResponseStr);
+
+    return G_SOURCE_REMOVE;
+}
+
+void ModemUssd::initiateCallback(MMModem3gppUssd* mmModem3gppUssd, GAsyncResult* result,
+                                 ModemUssd* self) {
+    GError* error = nullptr;
+    gchar* response = nullptr;
+
+    response = mm_modem_3gpp_ussd_initiate_finish(mmModem3gppUssd, result, &error);
+    if (error != nullptr) {
+        RLOGE("Failed to initiate USSD: %s", error->message);
+        g_error_free(error);
+        self->commonCallback(response, false);
+        return;
+    }
+    self->commonCallback(response, true);
+}
+
+void ModemUssd::responseCallback(MMModem3gppUssd* mmModem3gppUssd, GAsyncResult* result,
+                                 ModemUssd* self) {
+    GError* error = nullptr;
+    gchar* response = nullptr;
+
+    response = mm_modem_3gpp_ussd_initiate_finish(mmModem3gppUssd, result, &error);
+    if (error != nullptr) {
+        RLOGE("Failed to respond USSD: %s", error->message);
+        g_error_free(error);
+        self->commonCallback(response, false);
+        return;
+    }
+    self->commonCallback(response, true);
+}
+
+void ModemUssd::cancelCallback(MMModem3gppUssd* mmModem3gppUssd, GAsyncResult* result,
+                               ModemUssd* /*self*/) {
+    GError* error = nullptr;
+    mm_modem_3gpp_ussd_cancel_finish(mmModem3gppUssd, result, &error);
+    if (error != nullptr) {
+        RLOGE("Failed to cancel USSD: %s", error->message);
+        g_error_free(error);
+    }
+}
+
+std::shared_ptr<ModemUssd> ModemUssd::createInstance(SharedMmObject& mmObject) {
+    auto inst = std::shared_ptr<ModemUssd>(new ModemUssd());
+    inst->mMmModem3gppUssd =
+            makeSharedGObject<MMModem3gppUssd>(mm_object_get_modem_3gpp_ussd(mmObject.get()));
+
+    return inst;
+}
+
+void ModemUssd::sendUssd(const std::string& code) {
+    if (!isSessionActive())
+        mm_modem_3gpp_ussd_initiate(mMmModem3gppUssd.get(), code.c_str(), nullptr,
+                                    (GAsyncReadyCallback)initiateCallback, this);
+    else
+        mm_modem_3gpp_ussd_respond(mMmModem3gppUssd.get(), code.c_str(), nullptr,
+                                   (GAsyncReadyCallback)responseCallback, this);
+}
+
+void ModemUssd::cancelSession() {
+    mm_modem_3gpp_ussd_cancel(mMmModem3gppUssd.get(), nullptr, (GAsyncReadyCallback)cancelCallback,
+                              this);
+}
+
+bool ModemUssd::isSessionActive() {
+    auto state = mm_modem_3gpp_ussd_get_state(mMmModem3gppUssd.get());
+    switch (state) {
+        case MM_MODEM_3GPP_USSD_SESSION_STATE_ACTIVE:
+        case MM_MODEM_3GPP_USSD_SESSION_STATE_USER_RESPONSE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void ModemUssd::commonCallback(gchar* response, bool success) {
+    /* internal state that mean responce error */
+    auto state = MM_MODEM_3GPP_USSD_SESSION_STATE_UNKNOWN;
+
+    ALOGD("USSD response: %s", response);
+    mResponseStr = (response != nullptr) ? response : "";
+
+    if (!success) {
+        if (mUssdReceivedCallback != nullptr) mUssdReceivedCallback(state, mResponseStr);
+    } else {
+        // Call callback delayed to allow modem manager to change state
+        constexpr int kDelayMs = 100;
+        g_timeout_add(kDelayMs, (GSourceFunc)ModemUssd::commonCallbackFunc, this);
+    }
+
+    g_free(response);
+}

--- a/src/mm/ModemUssd.h
+++ b/src/mm/ModemUssd.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "MmRaii.h"
+
+#include <libmm-glib.h>
+
+using UssdCallback = std::function<void(MMModem3gppUssdSessionState, const std::string&)>;
+
+class ModemUssd {
+  public:
+    static std::shared_ptr<ModemUssd> createInstance(SharedMmObject& mmObject);
+
+    void sendUssd(const std::string& code);
+    void cancelSession();
+
+    void setUssdReceivedCallback(UssdCallback ussdReceivedCallback) {
+        mUssdReceivedCallback = std::move(ussdReceivedCallback);
+    }
+
+  private:
+    ModemUssd() = default;
+
+    bool isSessionActive();
+
+    std::string mResponseStr;
+
+    void commonCallback(gchar* response, bool success);
+
+    static auto commonCallbackFunc(ModemUssd* self) -> int;
+    static void initiateCallback(MMModem3gppUssd* mmModem3gppUssd, GAsyncResult* result,
+                                 ModemUssd* self);
+    static void responseCallback(MMModem3gppUssd* mmModem3gppUssd, GAsyncResult* result,
+                                 ModemUssd* self);
+    static void cancelCallback(MMModem3gppUssd* mmModem3gppUssd, GAsyncResult* result,
+                               ModemUssd* self);
+    UssdCallback mUssdReceivedCallback;
+
+    SharedGObject<MMModem3gppUssd> mMmModem3gppUssd;
+};


### PR DESCRIPTION
USSD requests that require user interactions doesn't work on EC25 modem, but it looks like the issue is not in HAL, but somewere in lower-level components (modem manager, libqmi, or the modem firmware itself).
